### PR TITLE
Add check for semver violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,10 @@ jobs:
         with:
           components: rust-src
       - run: cargo test
+
+  semver:
+    name: Check semver violations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
Use `cargo-semver-checks` to check for semver violations in CI.